### PR TITLE
Pass invoking certificate via registry

### DIFF
--- a/plugins/chapiv1rpc/chapi/HandlerBase.py
+++ b/plugins/chapiv1rpc/chapi/HandlerBase.py
@@ -27,6 +27,8 @@ import os
 import traceback
 from Exceptions import *
 
+import tools.cert_registry as cert_registry
+
 # Base class for API handlers, which can have 
 #   plug-replaceable delegates and guards
 class HandlerBase(object):
@@ -75,7 +77,7 @@ class HandlerBase(object):
 
     def requestCertificate(self):
         # *** get this from env ***
-        cert = ""
+        cert = cert_registry.lookup_client_cert()
         if not cert:
             raise CHAPIv1AuthorizationError('Client certificate required but not provided')
         return cert

--- a/plugins/chapiv1rpc/chapi/MethodContext.py
+++ b/plugins/chapiv1rpc/chapi/MethodContext.py
@@ -32,8 +32,6 @@ import sys
 import threading
 import traceback
 
-import tools.cert_registry as cert_registry
-
 # Class to wrap all calls from handlers to delegates
 # Holding method context
 # 
@@ -97,9 +95,9 @@ class MethodContext:
         self._client_cert = None
         self._email = None
         if self._cert_required:
-            if 'ENVIRON' in options and 'SSL_CLIENT_CERT' in options['ENVIRON']:
-                self._client_cert = options['ENVIRON']['SSL_CLIENT_CERT']
-#            self._client_cert = self._handler.requestCertificate()
+#            if 'ENVIRON' in options and 'SSL_CLIENT_CERT' in options['ENVIRON']:
+#                self._client_cert = options['ENVIRON']['SSL_CLIENT_CERT']
+            self._client_cert = self._handler.requestCertificate()
             if not self._client_cert:
                 raise CHAPIv1ArgumentError("No request certificate")
 

--- a/tools/ch_server.py
+++ b/tools/ch_server.py
@@ -88,7 +88,7 @@ import plugins.sarm.plugin
 
 from tools.chapi_log import *
 
-# import cert_registry
+import tools.cert_registry as cert_registry
 
 initialized = False
 
@@ -153,10 +153,10 @@ def handle_XMLRPC_call(environ):
 #        print "ARGS = %s INDEX = %s FCN_ARGS = %s" % (args, options_index, fcn_args)
         if len(args) <= options_index:
             args = ({},) # Empty default options argument
-        args[options_index]['ENVIRON'] = environ
+        # args[options_index]['ENVIRON'] = environ
 
         
-#    cert_registry.register_client_cert(environ['SSL_CLIENT_CERT'])
+    cert_registry.register_client_cert(environ['SSL_CLIENT_CERT'])
 #    print "XMLRPC.FCN = %s, ARGS = %s" % (fcn, args)
 #    print "LOOKUP-A %s" % cert_registry.lookup_client_cert()
 


### PR DESCRIPTION
Take out the temporary environment passing and instead pass the
certificate via the registry object.
